### PR TITLE
Use :erlang.nif_error/1 in hex doc

### DIFF
--- a/rustler_mix/guides/Basics.md
+++ b/rustler_mix/guides/Basics.md
@@ -59,7 +59,7 @@ defmodule MyProject.MyModule do
 
   # When loading a NIF module, dummy clauses for all NIF function are required.
   # NIF dummies usually just error out when called when the NIF is not loaded, as that should never normally happen.
-  def my_native_function(_arg1, _arg2), do: exit(:nif_not_loaded)
+  def my_native_function(_arg1, _arg2), do: :erlang.nif_error(:nif_not_loaded)
 end
 ```
 


### PR DESCRIPTION
By using :erlang.nif_error/1, false warnings from Dialyzer are suppressed. This should help
users new to Rustler to avoid useless warnings.